### PR TITLE
Fix: [EDG-4001] Using a new circle ci api tool and improving the danger report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,71 +7,73 @@ workflows:
 jobs:
   build:
     docker:
-    - image: circleci/ruby:2.7.1
-      environment:
-        RUBYOPT: '-W0 -KU -E utf-8:utf-8'
+      - image: circleci/ruby:2.7.1
+        environment:
+          RUBYOPT: "-W0 -KU -E utf-8:utf-8"
 
     steps:
-    - checkout
-    - run:
-        name: Install Cmake
-        command: sudo apt-get install cmake
-    - restore_cache:
-        keys:
-          - edge-bundle-{{ checksum "Gemfile.lock" }}
-          - edge-bundle-
-    - run:
-        name: Bundle Check or Install
-        command: bundle check --path vendor/bundle || bundle install --jobs=4 --retry=3 --path vendor/bundle
-    - save_cache:
-        key: edge-bundle-{{ checksum "Gemfile.lock" }}
-        paths:
-          - vendor/bundle
-    - run:
-        name: Lint code
-        command: bundle exec rubocop
-    - run:
-        name: Execute Rspec Tests
-        command: |
-          mkdir -p /tmp/coverage
-          bundle exec rspec
-    - run:
-        name: Store coverage report
-        command: |
-          mv coverage/coverage.json /tmp/coverage/
-          mv coverage/badge.svg /tmp/coverage/
-    - persist_to_workspace:
-        root: /tmp/coverage
-        paths: .
-    - store_artifacts:
-        path: /tmp/coverage
-        destination: coverage
-    - run:
-        name: Run Danger
-        command: bundle exec danger
-    - run:
-        name: Upload coverage to be persistent
-        command: |
-          mkdir -p /tmp/internal
-          cd /tmp/internal
-          git config --global user.email "bot@edgepetrol.com"
-          git config --global user.name "EdgeBot"
-          git clone https://EdgePetrolBot:${DANGER_GITHUB_API_TOKEN}@github.com/EdgePetrol/coverage.git
-          cd coverage
-          mkdir -p ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
-          mv /tmp/coverage/* /tmp/internal/coverage/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
-          git add . && git commit -m "Add ${CIRCLE_PROJECT_REPONAME} coverage"
-          git push --set-upstream origin master
-    - run:
-        name: Run gem build and push
-        command: |-
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+      - checkout
+      - run:
+          name: Install Cmake
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y cmake
+      - restore_cache:
+          keys:
+            - edge-bundle-{{ checksum "Gemfile.lock" }}
+            - edge-bundle-
+      - run:
+          name: Bundle Check or Install
+          command: bundle check --path vendor/bundle || bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          key: edge-bundle-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - run:
+          name: Lint code
+          command: bundle exec rubocop
+      - run:
+          name: Execute Rspec Tests
+          command: |
+            mkdir -p /tmp/coverage
+            bundle exec rspec
+      - run:
+          name: Store coverage report
+          command: |
+            mv coverage/coverage.json /tmp/coverage/
+            mv coverage/badge.svg /tmp/coverage/
+      - persist_to_workspace:
+          root: /tmp/coverage
+          paths: .
+      - store_artifacts:
+          path: /tmp/coverage
+          destination: coverage
+      - run:
+          name: Run Danger
+          command: bundle exec danger
+      - run:
+          name: Upload coverage to be persistent
+          command: |
+            mkdir -p /tmp/internal
+            cd /tmp/internal
             git config --global user.email "bot@edgepetrol.com"
             git config --global user.name "EdgeBot"
-            gem install gem-release --no-document
-            gem bump --skip-ci
-            git remote set-url --push origin https://EdgePetrolBot:${EDGE_GITHUB_API_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git
-            git push --set-upstream origin ${CIRCLE_BRANCH}
-            GEM_VERSION=$(gem build | awk '/File/ {print $2}')
-            curl -X POST https://rubygems.org/api/v1/gems -H "Authorization:${RUBY_GEMS_API_TOKEN}" -H "Content-Type: application/gem" --data-binary "@${GEM_VERSION}"
-          fi
+            git clone https://EdgePetrolBot:${DANGER_GITHUB_API_TOKEN}@github.com/EdgePetrol/coverage.git
+            cd coverage
+            mkdir -p ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
+            mv /tmp/coverage/* /tmp/internal/coverage/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
+            git add . && git commit -m "Add ${CIRCLE_PROJECT_REPONAME} coverage"
+            git push --set-upstream origin master
+      - run:
+          name: Run gem build and push
+          command: |-
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              git config --global user.email "bot@edgepetrol.com"
+              git config --global user.name "EdgeBot"
+              gem install gem-release --no-document
+              gem bump --skip-ci
+              git remote set-url --push origin https://EdgePetrolBot:${EDGE_GITHUB_API_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git
+              git push --set-upstream origin ${CIRCLE_BRANCH}
+              GEM_VERSION=$(gem build | awk '/File/ {print $2}')
+              curl -X POST https://rubygems.org/api/v1/gems -H "Authorization:${RUBY_GEMS_API_TOKEN}" -H "Content-Type: application/gem" --data-binary "@${GEM_VERSION}"
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           name: Install Cmake
           command: |
-            sudo apt-get update
+            sudo apt-get --allow-releaseinfo-change update
             sudo apt-get install -y cmake
       - restore_cache:
           keys:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 # Defaults can be found here: https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+AllCops:
+  TargetRubyVersion: 2.5
 
 # If you don't like these settings, just delete this file :)
 

--- a/danger-rcov.gemspec
+++ b/danger-rcov.gemspec
@@ -2,7 +2,7 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'rcov/gem_version.rb'
+require 'rcov/gem_version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'danger-rcov'
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %(Plugin that allows code coverage print)
   spec.homepage      = 'https://github.com/EdgePetrol/danger-rcov'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -8,9 +8,10 @@ module Danger
   class DangerRcov < Plugin
     # report will get the urls from circleCi trough circle_ci_wrapper gem
     def report(branch_name = 'master', build_name = 'build', show_warning = true)
-      puts "Start debugging..."
+      puts "Start debugging for branch_name = #{branch_name}, build_name = #{build_name}..."
 
       current_url, master_url = CircleCiWrapper.report_urls_by_branch(branch_name, build_name)
+      "#{CIRCLE_CI_API_URL}/#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}"
 
       p current_url
       p master_url

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -8,8 +8,6 @@ module Danger
   class DangerRcov < Plugin
     # report is called by client Dangerfiles (f.e.: https://github.com/EdgePetrol/edge-danger/blob/master/Dangerfile#L15)
     def report(pull_request_target_branch_name, build_job_name)
-      pull_request_source_branch_name = ENV["CIRCLE_BRANCH"]
-
       target_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_target_branch_name, build_job_name)
       source_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_source_branch_name, build_job_name)
 
@@ -93,6 +91,10 @@ module Danger
       else
         response
       end
+    end
+
+    def pull_request_source_branch_name
+      ENV["CIRCLE_BRANCH"]
     end
 
     def github_project

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -39,6 +39,7 @@ module Danger
       page = 0
       while true
         branch_builds_api = "https://circleci.com/api/v1.1/project/github/#{gh_project}/#{gh_repo}/tree/#{branch_name}?circle-token=#{circleci_token}&limit=#{number_of_build_items_per_page}&filter=completed&offset=#{page * number_of_build_items_per_page}"
+        puts "branch_builds_api: #{branch_builds_api}"
         branch_builds = JSON.parse(URI.parse(url).read, { max_nesting: 5 })
         if branch_builds.length == 0
           return nil
@@ -48,6 +49,7 @@ module Danger
           if branch_build.dig("workflows", "job_name") == build_job_name && branch_build.dig("has_artifacts")
             build_number = branch_build.dig("build_num")
             build_artifacts_api = "https://circleci.com/api/v1.1/project/github/#{gh_project}/#{gh_repo}/#{build_number}/artifacts?circle-token=#{circleci_token}"
+            puts "build_artifacts_api: #{build_artifacts_api}"
             build_artifacts = JSON.parse(URI.parse(url).read, { max_nesting: 3 })
             for build_artifact in build_artifacts
               if build_artifact.dig("path") == "coverage/coverage.json"

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -84,7 +84,7 @@ module Danger
     def get_circleci_url_with_redirect_follow(url, max_redirects = 10)
       raise ArgumentError, "too many HTTP redirects" if max_redirects == 0
 
-      response = get_circleci_url(url, max_redirects - 1)
+      response = get_circleci_url(url)
 
       case response
       when Net::HTTPRedirection

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -70,7 +70,7 @@ module Danger
     end
 
     def get_circleci_url(url)
-      uri = URI(api)
+      uri = URI(url)
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -40,7 +40,7 @@ module Danger
         for branch_build in branch_builds
           if branch_build.dig("workflows", "job_name") == build_job_name && branch_build.dig("has_artifacts")
             build_number = branch_build.dig("build_num")
-            build_artifacts = get_build_artifacts()
+            build_artifacts = get_build_artifacts(build_number)
             for build_artifact in build_artifacts
               # We assume the coverage reports file were stored in "coverage/coverage.json" by previous steps.
               if build_artifact.dig("path") == "coverage/coverage.json"
@@ -63,7 +63,7 @@ module Danger
       return JSON.parse(get_circleci_url(url), { max_nesting: 5 })
     end
 
-    def get_build_artifacts()
+    def get_build_artifacts(build_number)
       # Ref.: https://circleci.com/docs/api/v2/#operation/getJobArtifacts
       url = "https://circleci.com/api/v2/project/github/#{github_project}/#{github_repo}/#{build_number}/artifacts"
       return JSON.parse(get_circleci_url(url), { max_nesting: 3 })

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -41,7 +41,7 @@ module Danger
           if branch_build.dig("workflows", "job_name") == build_job_name && branch_build.dig("has_artifacts")
             build_number = branch_build.dig("build_num")
             build_artifacts = get_build_artifacts(build_number)
-            for build_artifact in build_artifacts
+            for build_artifact in build_artifacts.dig("items")
               # We assume the coverage reports file were stored in "coverage/coverage.json" by previous steps.
               if build_artifact.dig("path") == "coverage/coverage.json"
                 # See: https://circleci.com/docs/api/#download-an-artifact-file

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -31,7 +31,7 @@ module Danger
       page_limit = 30
       page = 0
       while true
-        branch_builds = get_branch_builds(page_limit, page * page_limit)
+        branch_builds = get_branch_builds(branch_name, page_limit, page * page_limit)
         if branch_builds.length == 0
           # Reached the end of the builds list, but couldn't find what we wanted yet.
           return nil
@@ -57,7 +57,7 @@ module Danger
       end
     end
 
-    def get_branch_builds(limit, offset)
+    def get_branch_builds(branch_name, limit, offset)
       # See: https://circleci.com/docs/api/#recent-builds-for-a-single-project
       url = "https://circleci.com/api/v1.1/project/github/#{github_project}/#{github_repo}/tree/#{branch_name}?circle-token=#{circleci_token}&limit=#{limit}&filter=completed&offset=#{offset}"
       return JSON.parse(get_circleci_url(url), { max_nesting: 5 })

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -7,7 +7,7 @@ require "circle_ci_wrapper"
 module Danger
   class DangerRcov < Plugin
     # report will get the urls from circleCi trough circle_ci_wrapper gem
-    def report(default_branch_name, pull_request_target_branch_name, show_warning)
+    def report(pull_request_target_branch_name, build_job_name)
       puts "Start debugging for branch_name = #{branch_name}, build_name = #{build_name}..., show_warning = #{show_warning}"
 
       pull_request_source_branch_name = ENV["CIRCLE_BRANCH"]

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -8,7 +8,6 @@ module Danger
   class DangerRcov < Plugin
     # report is called by client Dangerfiles (f.e.: https://github.com/EdgePetrol/edge-danger/blob/master/Dangerfile#L15)
     def report(pull_request_target_branch_name, build_job_name)
-      p ENV
       target_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_target_branch_name, build_job_name)
       source_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_source_branch_name, build_job_name)
 

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -8,17 +8,18 @@ module Danger
   class DangerRcov < Plugin
     # report will get the urls from circleCi trough circle_ci_wrapper gem
     def report(branch_name = 'master', build_name = 'build', show_warning = true)
-      print "Start debugging..."
+      puts "Start debugging..."
 
       current_url, master_url = CircleCiWrapper.report_urls_by_branch(branch_name, build_name)
 
-      print current_url
-      print master_url
+      puts current_url
+      puts master_url
 
       report_by_urls(current_url, master_url, show_warning)
     end
 
     def report_by_urls(current_url, master_url, show_warning = true)
+      puts "Hello"
       # Get code coverage report as json from url
       @current_report = get_report(url: current_url)
       @master_report = get_report(url: master_url)

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: false
 
-require "open-uri"
 require "net/http"
-require "circle_ci_wrapper"
 
 module Danger
   class DangerRcov < Plugin

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -9,6 +9,7 @@ module Danger
     # report will get the urls from circleCi trough circle_ci_wrapper gem
     def report(branch_name = 'master', build_name = 'build', show_warning = true)
       puts "Start debugging..."
+      puts "Debug log..."
 
       current_url, master_url = CircleCiWrapper.report_urls_by_branch(branch_name, build_name)
 

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -40,7 +40,7 @@ module Danger
       while true
         branch_builds_api = "https://circleci.com/api/v1.1/project/github/#{gh_project}/#{gh_repo}/tree/#{branch_name}?circle-token=#{circleci_token}&limit=#{number_of_build_items_per_page}&filter=completed&offset=#{page * number_of_build_items_per_page}"
         puts "branch_builds_api: #{branch_builds_api}"
-        branch_builds = JSON.parse(URI.parse(url).read, { max_nesting: 5 })
+        branch_builds = JSON.parse(URI.parse(branch_builds_api).read, { max_nesting: 5 })
         if branch_builds.length == 0
           return nil
         end
@@ -50,7 +50,7 @@ module Danger
             build_number = branch_build.dig("build_num")
             build_artifacts_api = "https://circleci.com/api/v1.1/project/github/#{gh_project}/#{gh_repo}/#{build_number}/artifacts?circle-token=#{circleci_token}"
             puts "build_artifacts_api: #{build_artifacts_api}"
-            build_artifacts = JSON.parse(URI.parse(url).read, { max_nesting: 3 })
+            build_artifacts = JSON.parse(URI.parse(build_artifacts_api).read, { max_nesting: 3 })
             for build_artifact in build_artifacts
               if build_artifact.dig("path") == "coverage/coverage.json"
                 return JSON.parse(URI.parse(build_artifact.dig("url")).read)

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -45,7 +45,7 @@ module Danger
               # We assume the coverage reports file were stored in "coverage/coverage.json" by previous steps.
               if build_artifact.dig("path") == "coverage/coverage.json"
                 artifact_file_url = build_artifact.dig("url")
-                return JSON.parse(get_circleci_url(artifact_file_url).read_body)
+                return JSON.parse(get_circleci_url_with_redirect_follow(artifact_file_url).read_body)
               end
             end
           end

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -46,7 +46,7 @@ module Danger
               if build_artifact.dig("path") == "coverage/coverage.json"
                 # See: https://circleci.com/docs/api/#download-an-artifact-file
                 artifact_file_url = build_artifact.dig("url")
-                return JSON.parse(URI.parse("#{artifact_file_url}?circle-token=#{circleci_token}").read)
+                return JSON.parse(get_circleci_url(artifact_file_url))
               end
             end
           end

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -35,10 +35,10 @@ module Danger
     # the latest coverage reports of the target branch with the pull request branch, which is
     # possibly generated in the current job run by previous steps.
     def find_latest_branch_coverage_report_with_job(branch_name, build_job_name)
-      page_limit = 30
+      per_page_build_items = 30
       page = 0
       while true
-        branch_builds = get_branch_builds(branch_name, page_limit, page * page_limit)
+        branch_builds = get_branch_builds(branch_name, per_page_build_items, page * per_page_build_items)
         if branch_builds.length == 0
           # Reached the end of the builds list, but couldn't find what we wanted yet.
           return nil

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -46,8 +46,9 @@ module Danger
         end
 
         for branch_build in branch_builds
-          if branch_build.dig("workflows", "job_name") == build_job_name && branch_build.dig("has_artifacts")
-            build_number = branch_build.dig("build_num")
+          if branch_build&.dig("workflows", "job_name") == build_job_name && branch_build&.dig("has_artifacts")
+            build_number = branch_build&.dig("build_num")
+            p branch_build
             build_artifacts_api = "https://circleci.com/api/v1.1/project/github/#{gh_project}/#{gh_repo}/#{build_number}/artifacts?circle-token=#{circleci_token}"
             puts "build_artifacts_api: #{build_artifacts_api}"
             build_artifacts = JSON.parse(URI.parse(build_artifacts_api).read, { max_nesting: 3 })

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -8,7 +8,12 @@ module Danger
   class DangerRcov < Plugin
     # report will get the urls from circleCi trough circle_ci_wrapper gem
     def report(branch_name = 'master', build_name = 'build', show_warning = true)
+      print "Start debugging..."
+
       current_url, master_url = CircleCiWrapper.report_urls_by_branch(branch_name, build_name)
+
+      print current_url
+      print master_url
 
       report_by_urls(current_url, master_url, show_warning)
     end

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: false
 
 require "net/http"
+require "open-uri"
 
 module Danger
   class DangerRcov < Plugin

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -8,7 +8,7 @@ module Danger
   class DangerRcov < Plugin
     # report will get the urls from circleCi trough circle_ci_wrapper gem
     def report(pull_request_target_branch_name, build_job_name)
-      puts "Start debugging for branch_name = #{branch_name}, build_name = #{build_name}..."
+      puts "Start debugging for pull_request_target_branch_name = #{pull_request_target_branch_name}, build_job_name = #{build_job_name}..."
 
       pull_request_source_branch_name = ENV["CIRCLE_BRANCH"]
 

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -5,14 +5,14 @@ require "open-uri"
 
 module Danger
   class DangerRcov < Plugin
-    # report is called by client Dangerfiles
+    # report is called by client Dangerfiles (f.e.: https://github.com/EdgePetrol/edge-danger/blob/master/Dangerfile#L15)
     def report(pull_request_target_branch_name, build_job_name)
       pull_request_source_branch_name = ENV["CIRCLE_BRANCH"]
 
       target_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_target_branch_name, build_job_name)
       source_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_source_branch_name, build_job_name)
 
-      output_report(source_branch_coverage, target_branch_coverage)
+      print_report_diff(source_branch_coverage, target_branch_coverage)
     end
 
     private
@@ -59,11 +59,12 @@ module Danger
           end
         end
 
+        # Maybe in the next builds page?
         page += 1
       end
     end
 
-    def output_report(source_branch_coverage, target_branch_coverage)
+    def print_report_diff(source_branch_coverage, target_branch_coverage)
       source_branch_covered_percent = source_branch_coverage&.dig("metrics", "covered_percent")&.round(2)
       source_branch_files_count = source_branch_coverage&.dig("files")&.count
       source_branch_total_lines = source_branch_coverage&.dig("metrics", "total_lines")

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -50,6 +50,9 @@ module Danger
             build_number = branch_build&.dig("build_num")
             p branch_build
             build_artifacts_api = "https://circleci.com/api/v1.1/project/github/#{gh_project}/#{gh_repo}/#{build_number}/artifacts?circle-token=#{circleci_token}"
+            res = Net::HTTP.get_response(URI.parse(build_artifacts_api))
+            puts res.code
+            puts res.body
             puts "build_artifacts_api: #{build_artifacts_api}"
             build_artifacts = JSON.parse(URI.parse(build_artifacts_api).read, { max_nesting: 3 })
             for build_artifact in build_artifacts

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -9,21 +9,28 @@ module Danger
     # report will get the urls from circleCi trough circle_ci_wrapper gem
     def report(branch_name = 'master', build_name = 'build', show_warning = true)
       puts "Start debugging..."
-      puts "Debug log..."
 
       current_url, master_url = CircleCiWrapper.report_urls_by_branch(branch_name, build_name)
 
-      puts current_url
-      puts master_url
+      p current_url
+      p master_url
 
       report_by_urls(current_url, master_url, show_warning)
     end
 
     def report_by_urls(current_url, master_url, show_warning = true)
-      puts "Hello"
+      print "current_url: "
+      p current_url
+      print "master_url: "
+      p master_url
+
       # Get code coverage report as json from url
       @current_report = get_report(url: current_url)
+      print "@current_report: "
+      p @current_report
       @master_report = get_report(url: master_url)
+      print "@master_report: "
+      p @master_report
 
       if show_warning && @master_report && @master_report.dig('metrics', 'covered_percent').round(2) > @current_report.dig('metrics', 'covered_percent').round(2)
         warn("Code coverage decreased from #{@master_report.dig('metrics', 'covered_percent').round(2)}% to #{@current_report.dig('metrics', 'covered_percent').round(2)}%")
@@ -40,9 +47,15 @@ module Danger
     end
 
     def output_report(results, master_results)
+      print "results: "
+      p results
+      print "master_results: "
+      p master_results
       @current_covered_percent = results&.dig('metrics', 'covered_percent')&.round(2)
       @current_files_count = results&.dig('files')&.count
       @current_total_lines = results&.dig('metrics', 'total_lines')
+      print "@current_total_lines: "
+      p @current_total_lines
       @current_misses_count = @current_total_lines - results&.dig('metrics', 'covered_lines')
 
       if master_results

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -1,20 +1,31 @@
 # frozen_string_literal: false
 
-require 'open-uri'
-require 'net/http'
-require 'circle_ci_wrapper'
+require "open-uri"
+require "net/http"
+require "circle_ci_wrapper"
 
 module Danger
   class DangerRcov < Plugin
     # report will get the urls from circleCi trough circle_ci_wrapper gem
-    def report(branch_name = 'master', build_name = 'build', show_warning = true)
+    def report(branch_name = "master", build_name = "build", show_warning = true)
       puts "Start debugging for branch_name = #{branch_name}, build_name = #{build_name}..."
 
-      current_url, master_url = CircleCiWrapper.report_urls_by_branch(branch_name, build_name)
-      "#{CIRCLE_CI_API_URL}/#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}"
+      api = "https://circleci.com/api/v1.1/project/github"
 
-      p current_url
-      p master_url
+      gh_project = ENV["CIRCLE_PROJECT_USERNAME"]
+      gh_repo = ENV["CIRCLE_PROJECT_REPONAME"]
+      repo_url = "#{api}/#{gh_project}/#{gh_repo}"
+      circleci_token = ENV["CIRCLE_TOKEN"]
+      url = "#{repo_url}/tree/#{branch_name}?circle-token=#{circleci_token}&limit=6&filter=completed"
+
+      res = Net::HTTP.get_response(URI.parse(url))
+
+      puts res.code
+      puts res.body
+
+      latest_build_num = latest_build(url, build_name)
+
+      puts latest_build_num
 
       report_by_urls(current_url, master_url, show_warning)
     end
@@ -33,8 +44,8 @@ module Danger
       print "@master_report: "
       p @master_report
 
-      if show_warning && @master_report && @master_report.dig('metrics', 'covered_percent').round(2) > @current_report.dig('metrics', 'covered_percent').round(2)
-        warn("Code coverage decreased from #{@master_report.dig('metrics', 'covered_percent').round(2)}% to #{@current_report.dig('metrics', 'covered_percent').round(2)}%")
+      if show_warning && @master_report && @master_report.dig("metrics", "covered_percent").round(2) > @current_report.dig("metrics", "covered_percent").round(2)
+        warn("Code coverage decreased from #{@master_report.dig("metrics", "covered_percent").round(2)}% to #{@current_report.dig("metrics", "covered_percent").round(2)}%")
       end
 
       # Output the processed report
@@ -42,6 +53,12 @@ module Danger
     end
 
     private
+
+    def latest_build(url, build_name)
+      JSON.parse(URI.parse(url).read).select do |build|
+        build&.[]("build_parameters")&.[]("CIRCLE_JOB") == build_name
+      end&.first&.[]("build_num")
+    end
 
     def get_report(url:)
       JSON.parse(URI.parse(url).read) if url
@@ -52,30 +69,30 @@ module Danger
       p results
       print "master_results: "
       p master_results
-      @current_covered_percent = results&.dig('metrics', 'covered_percent')&.round(2)
-      @current_files_count = results&.dig('files')&.count
-      @current_total_lines = results&.dig('metrics', 'total_lines')
+      @current_covered_percent = results&.dig("metrics", "covered_percent")&.round(2)
+      @current_files_count = results&.dig("files")&.count
+      @current_total_lines = results&.dig("metrics", "total_lines")
       print "@current_total_lines: "
       p @current_total_lines
-      @current_misses_count = @current_total_lines - results&.dig('metrics', 'covered_lines')
+      @current_misses_count = @current_total_lines - results&.dig("metrics", "covered_lines")
 
       if master_results
-        @master_covered_percent = master_results&.dig('metrics', 'covered_percent')&.round(2)
-        @master_files_count = master_results.dig('files')&.count
-        @master_total_lines = master_results.dig('metrics', 'total_lines')
-        @master_misses_count = @master_total_lines - master_results.dig('metrics', 'covered_lines')
+        @master_covered_percent = master_results&.dig("metrics", "covered_percent")&.round(2)
+        @master_files_count = master_results.dig("files")&.count
+        @master_total_lines = master_results.dig("metrics", "total_lines")
+        @master_misses_count = @master_total_lines - master_results.dig("metrics", "covered_lines")
       end
 
       message = "```diff\n@@           Coverage Diff            @@\n"
-      message << "## #{justify_text('master', 16)} #{justify_text('#' + ENV['CIRCLE_PULL_REQUEST'].split('/').last, 8)} #{justify_text('+/-', 7)} #{justify_text('##', 3)}\n"
+      message << "## #{justify_text("master", 16)} #{justify_text("#" + ENV["CIRCLE_PULL_REQUEST"].split("/").last, 8)} #{justify_text("+/-", 7)} #{justify_text("##", 3)}\n"
       message << separator_line
-      message << new_line('Coverage', @current_covered_percent, @master_covered_percent, '%')
+      message << new_line("Coverage", @current_covered_percent, @master_covered_percent, "%")
       message << separator_line
-      message << new_line('Files', @current_files_count, @master_files_count)
-      message << new_line('Lines', @current_total_lines, @master_total_lines)
+      message << new_line("Files", @current_files_count, @master_files_count)
+      message << new_line("Lines", @current_total_lines, @master_total_lines)
       message << separator_line
-      message << new_line('Misses', @current_misses_count, @master_misses_count)
-      message << '```'
+      message << new_line("Misses", @current_misses_count, @master_misses_count)
+      message << "```"
     end
 
     def separator_line
@@ -83,29 +100,29 @@ module Danger
     end
 
     def new_line(title, current, master, symbol = nil)
-      formatter = symbol ? '%+.2f' : '%+d'
+      formatter = symbol ? "%+.2f" : "%+d"
       currrent_formatted = current.to_s + symbol.to_s
-      master_formatted = master ? master.to_s + symbol.to_s : '-'
+      master_formatted = master ? master.to_s + symbol.to_s : "-"
       prep = calulate_prep(master_formatted, current - master)
 
       line = data_string(title, master_formatted, currrent_formatted, prep)
-      line << justify_text(format(formatter, current - master) + symbol.to_s, 8) if prep != '  '
+      line << justify_text(format(formatter, current - master) + symbol.to_s, 8) if prep != "  "
       line << "\n"
       line
     end
 
-    def justify_text(string, adjust, position = 'right')
-      string.send(position == 'right' ? :rjust : :ljust, adjust)
+    def justify_text(string, adjust, position = "right")
+      string.send(position == "right" ? :rjust : :ljust, adjust)
     end
 
     def data_string(title, master, current, prep)
-      "#{prep}#{justify_text(title, 9, 'left')} #{justify_text(master, 7)}#{justify_text(current, 9)}"
+      "#{prep}#{justify_text(title, 9, "left")} #{justify_text(master, 7)}#{justify_text(current, 9)}"
     end
 
     def calulate_prep(master_formatted, diff)
-      return '  ' if master_formatted != '-' && diff.zero?
+      return "  " if master_formatted != "-" && diff.zero?
 
-      diff.positive? ? '+ ' : '- '
+      diff.positive? ? "+ " : "- "
     end
   end
 end

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -106,6 +106,10 @@ module Danger
       ENV["CIRCLE_BRANCH"]
     end
 
+    def pull_request_id
+      "#" + ENV["CIRCLE_PULL_REQUEST"].split("/").last
+    end
+
     def github_project
       ENV["CIRCLE_PROJECT_USERNAME"]
     end
@@ -134,7 +138,7 @@ module Danger
       target_branch_name = branch_coverage_reports[:target][:branch_name]
 
       message = "```diff\n@@           Coverage Diff            @@\n"
-      message << "## #{justify_text(target_branch_name, 16)} #{justify_text("#" + ENV["CIRCLE_PULL_REQUEST"].split("/").last, 8)} #{justify_text("+/-", 7)} #{justify_text("##", 3)}\n"
+      message << "## #{justify_text(target_branch_name, 16)} #{justify_text(pull_request_id, 8)} #{justify_text("+/-", 7)} #{justify_text("##", 3)}\n"
       message << separator_line
       message << new_line("Coverage", source_branch_covered_percent, target_branch_covered_percent, "%")
       message << separator_line

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -7,11 +7,12 @@ require "circle_ci_wrapper"
 module Danger
   class DangerRcov < Plugin
     # report will get the urls from circleCi trough circle_ci_wrapper gem
-    def report(branch_name = "master", build_name, show_warning)
+    def report(branch_name, build_name, show_warning)
       puts "Start debugging for branch_name = #{branch_name}, build_name = #{build_name}..."
       puts "environment variables:"
       p ENV
-      # get_pull_request_target_branch_coverage_report()
+
+      # target_branch_coverage = get_pull_request_target_branch_coverage_report(ENV["CIRCLE_PULL_REQUEST"])
       # get_pull_request_source_branch_coverage_report(branch_name)
 
       api = "https://circleci.com/api/v1.1/project/github"

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -8,6 +8,7 @@ module Danger
   class DangerRcov < Plugin
     # report is called by client Dangerfiles (f.e.: https://github.com/EdgePetrol/edge-danger/blob/master/Dangerfile#L15)
     def report(pull_request_target_branch_name, build_job_name)
+      p ENV
       target_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_target_branch_name, build_job_name)
       source_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_source_branch_name, build_job_name)
 

--- a/lib/rcov/plugin.rb
+++ b/lib/rcov/plugin.rb
@@ -8,12 +8,12 @@ module Danger
   class DangerRcov < Plugin
     # report will get the urls from circleCi trough circle_ci_wrapper gem
     def report(pull_request_target_branch_name, build_job_name)
-      puts "Start debugging for branch_name = #{branch_name}, build_name = #{build_name}..., show_warning = #{show_warning}"
+      puts "Start debugging for branch_name = #{branch_name}, build_name = #{build_name}..."
 
       pull_request_source_branch_name = ENV["CIRCLE_BRANCH"]
 
-      target_branch_coverage = get_branch_coverage_report(pull_request_target_branch_name)
-      source_branch_coverage = get_branch_coverage_report(pull_request_source_branch_name)
+      target_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_target_branch_name, build_job_name)
+      source_branch_coverage = find_latest_branch_coverage_report_with_job(pull_request_source_branch_name, build_job_name)
 
       puts "target_branch_coverage (#{pull_request_target_branch_name}): "
       p target_branch_coverage.dig("metrics")
@@ -29,7 +29,7 @@ module Danger
 
     private
 
-    def get_branch_coverage_report(branch_name)
+    def find_latest_branch_coverage_report_with_job(branch_name, build_job_name)
       gh_project = ENV["CIRCLE_PROJECT_USERNAME"]
       gh_repo = ENV["CIRCLE_PROJECT_REPONAME"]
       circleci_token = ENV["CIRCLE_TOKEN"]
@@ -45,7 +45,7 @@ module Danger
         end
 
         for branch_build in branch_builds
-          if branch_build.dig("workflows", "job_name") == ENV["CIRCLE_JOB"] && branch_build.dig("has_artifacts")
+          if branch_build.dig("workflows", "job_name") == build_job_name && branch_build.dig("has_artifacts")
             build_number = branch_build.dig("build_num")
             build_artifacts_api = "https://circleci.com/api/v1.1/project/github/#{gh_project}/#{gh_repo}/#{build_number}/artifacts?circle-token=#{circleci_token}"
             build_artifacts = JSON.parse(URI.parse(url).read, { max_nesting: 3 })

--- a/spec/rcov_spec.rb
+++ b/spec/rcov_spec.rb
@@ -21,11 +21,11 @@ module Danger
         @dangerfile = testing_dangerfile
         @rcov_plugin = @dangerfile.rcov
 
-        @current_circle_ci = File.read(File.dirname(__FILE__) + '/support/fixtures/current_circle_ci.json')
-        @master_circle_ci = File.read(File.dirname(__FILE__) + '/support/fixtures/master_circle_ci.json')
+        @current_circle_ci = File.read("#{File.dirname(__FILE__)}/support/fixtures/current_circle_ci.json")
+        @master_circle_ci = File.read("#{File.dirname(__FILE__)}/support/fixtures/master_circle_ci.json")
 
-        @current_coverage = File.read(File.dirname(__FILE__) + '/support/fixtures/current_coverage.json')
-        @master_coverage = File.read(File.dirname(__FILE__) + '/support/fixtures/master_coverage.json')
+        @current_coverage = File.read("#{File.dirname(__FILE__)}/support/fixtures/current_coverage.json")
+        @master_coverage = File.read("#{File.dirname(__FILE__)}/support/fixtures/master_coverage.json")
       end
 
       it 'code coverage different' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,8 @@
 
 require 'pathname'
 ROOT = Pathname.new(File.expand_path('..', __dir__))
-$:.unshift((ROOT + 'lib').to_s)
-$:.unshift((ROOT + 'spec').to_s)
+$:.unshift("#{ROOT}lib".to_s)
+$:.unshift("#{ROOT}spec".to_s)
 
 require 'bundler/setup'
 


### PR DESCRIPTION
This pull request fixes the issue preventing the build job Danger step from reporting coverage reports. 
Here is an example of a successful Danger step run:
https://app.circleci.com/pipelines/github/EdgePetrol/test-data-service/479/workflows/51a30a35-88d1-418e-b0b4-af5ef7f2908d/jobs/1787
And its result in the respective pull request:
https://github.com/EdgePetrol/test-data-service/pull/142#issuecomment-1010875338